### PR TITLE
Add quizdb app header

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -99,9 +99,9 @@
     .navbar.shrink .navbar-links i.icon {
       font-size: 1em; }
   .navbar ~ * .quizdb-page {
-    padding-top: 8.5rem; }
+    padding-top: 12rem; }
   .navbar.mobile ~ * .quizdb-page {
-    padding-top: 5.5rem; }
+    padding-top: 9rem; }
 
 .ui.inverted.menu.quizdb-sidebar-close:hover {
   cursor: pointer;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -114,6 +114,29 @@
 .ui.inverted.menu.quizdb-sidebar > a.item:hover {
   color: #2185d0; }
 
+#header-hider {
+  -moz-animation: cssAnimation 0s ease-in 15s forwards;
+  /* Firefox */
+  -webkit-animation: cssAnimation 0s ease-in 15s forwards;
+  /* Safari and Chrome */
+  -o-animation: cssAnimation 0s ease-in 15s forwards;
+  /* Opera */
+  animation: cssAnimation 0s ease-in 15s forwards;
+  -webkit-animation-fill-mode: forwards;
+  animation-fill-mode: forwards; }
+
+@keyframes cssAnimation {
+  to {
+    width: 0;
+    height: 0;
+    overflow: hidden; } }
+
+@-webkit-keyframes cssAnimation {
+  to {
+    width: 0;
+    height: 0;
+    visibility: hidden; } }
+
 .root-credits {
   padding: 2rem 0;
   margin: 2rem 0;

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -84,7 +84,7 @@ class Navbar extends React.Component {
         </div>
       </Container>
       {!this.shown_banner &&
-      <div>
+      <div id="header-hider">
       <br />
       <center>
         <h1>Download the new <a href="https://itunes.apple.com/app/id1439712679">QuizDB</a> app for iOS!</h1>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -23,6 +23,11 @@ class Navbar extends React.Component {
     this.handleScroll = this.handleScroll.bind(this);
     this.handleBrandClick = this.handleBrandClick.bind(this);
     this.handleBurgerClick = this.handleBurgerClick.bind(this);
+    this.shown_banner = true;
+    if (!localStorage.getItem('shown-banner') || localStorage.getItem('shown-banner') === "false") {
+      this.shown_banner = false;
+    }
+    localStorage.setItem('shown-banner', true);
   }
 
   componentDidMount() {
@@ -78,10 +83,14 @@ class Navbar extends React.Component {
           </div>
         </div>
       </Container>
+      {!this.shown_banner &&
+      <div>
       <br />
       <center>
         <h1>Download the new <a href="https://itunes.apple.com/app/id1439712679">QuizDB</a> app for iOS!</h1>
       </center>
+      </div>
+      }
     </nav>
   }
 }

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -78,6 +78,10 @@ class Navbar extends React.Component {
           </div>
         </div>
       </Container>
+      <br />
+      <center>
+        <h1>Download the new <a href="https://itunes.apple.com/app/id1439712679">QuizDB</a> app for iOS!</h1>
+      </center>
     </nav>
   }
 }

--- a/client/src/sass/navbar.scss
+++ b/client/src/sass/navbar.scss
@@ -133,11 +133,11 @@
   }
 
   & ~ * .quizdb-page {
-    padding-top: 8.5rem;
+    padding-top: 12rem;
   }
 
   &.mobile ~ * .quizdb-page {
-    padding-top: 5.5rem;
+    padding-top: 9rem;
   }
 
 }

--- a/client/src/sass/navbar.scss
+++ b/client/src/sass/navbar.scss
@@ -165,3 +165,30 @@
     }
   }
 }
+
+#header-hider {
+    -moz-animation: cssAnimation 0s ease-in 15s forwards;
+    /* Firefox */
+    -webkit-animation: cssAnimation 0s ease-in 15s forwards;
+    /* Safari and Chrome */
+    -o-animation: cssAnimation 0s ease-in 15s forwards;
+    /* Opera */
+    animation: cssAnimation 0s ease-in 15s forwards;
+    -webkit-animation-fill-mode: forwards;
+    animation-fill-mode: forwards;
+}
+
+@keyframes cssAnimation {
+    to {
+        width:0;
+        height:0;
+        overflow:hidden;
+    }
+}
+@-webkit-keyframes cssAnimation {
+    to {
+        width:0;
+        height:0;
+        visibility:hidden;
+    }
+}


### PR DESCRIPTION
<img width="1279" alt="screenshot 2019-01-21 20 33 57" src="https://user-images.githubusercontent.com/21976953/51506786-ff403a80-1dbb-11e9-8f6e-4a9839210728.png">

Add a header to the `Navbar` component.
Only shows once per user (`localStorage.getItem("shown-banner")`)
Disappears after 15 seconds (`#header-hider` in `navbar.scss`)

I'm Simon Chervenak, part of the QuizDB app dev team, in conjunction with Matthew Shu.