### PR TITLE
Attempted fixes for several bugs

### DIFF
--- a/client/src/utilities/Question.js
+++ b/client/src/utilities/Question.js
@@ -65,7 +65,9 @@ export function extractBonusText(bonus) {
 }
 
 export function extractActualAnswer(answer) {
-  const regMatch = answer.match(/<b>.*<\/b>/) || answer.match(/<strong>.*<\/strong>/);
+  //naively match the beginning of a question up to (but not including) the first left square brace
+  //if more powerful solution is needed, use lookahead like (?:(?!\[).)* and replace \[ as needed
+  const regMatch = answer.match(/^[^\[]*/);
   return regMatch ? regMatch[0] : null;
 }
 


### PR DESCRIPTION
Copying answerlines should now give actual text instead of [object Object], all answerline actions should now use the text before the first square brace instead of the bolded text, and quotation marks in the confirmation text should now be escaped. All 3rd party icon buttons should now have tooltips.

It is very, very, very important to note that **NONE OF THIS IS TESTED** - I'm not about to install Ubuntu on my computer to get Ruby on Rails running.